### PR TITLE
Update Python version support and pin dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "stuntdouble"
 version = "2.0.1"
 description = "Tool mocking framework for AI agent testing"
-requires-python = ">= 3.11"
+requires-python = ">= 3.12"
 license = "MIT"
 authors = [{ name = "Benjamin Benchaya" }]
 readme = "README.md"
@@ -10,26 +10,25 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
-    "langchain-core>=1.2.5",
-    "pydantic>=2.0.0",
-    "langgraph>=1.0.0",
+    "langchain-core>=1.2.5,<2",
+    "pydantic>=2.0.0,<3",
+    "langgraph>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]
-mcp = ["aiohttp>=3.9.0"]
+mcp = ["aiohttp>=3.9.0,<4"]
 
 [dependency-groups]
-dev = ["pytest", "pytest-cov", "pytest-xdist", "pytest-asyncio", "mypy", "ruff", "langchain-openai"]
-docs = ["sphinx>=7.0.0", "myst-parser>=3.0.0", "sphinx-rtd-theme>=2.0.0", "sphinx-copybutton>=0.5.0"]
+dev = ["pytest>=9.0.0,<10", "pytest-cov>=7.0.0,<8", "pytest-xdist>=3.8.0,<4", "pytest-asyncio>=1.3.0,<2", "mypy>=1.19.0,<2", "ruff>=0.15.0,<1", "langchain-openai>=1.1.0,<2"]
+docs = ["sphinx>=9.0.0,<10", "myst-parser>=5.0.0,<6", "sphinx-rtd-theme>=3.0.0,<4", "sphinx-copybutton>=0.5.0,<1"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.29.0,<2"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
@@ -55,6 +54,6 @@ Issues = "https://github.com/stuntdouble/stuntdouble/issues"
 testpaths = ["tests"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
Drop Python 3.11 support (minimum now 3.12), add upper-bound version constraints to all dependencies to prevent unexpected breaking changes.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

Fixes #(issue number)

Thank you!
