### PR TITLE
fix: derive __version__ from package metadata

### DIFF
--- a/src/stuntdouble/__init__.py
+++ b/src/stuntdouble/__init__.py
@@ -1,5 +1,7 @@
 """StuntDouble — Tool mocking framework for AI agent testing."""
 
+from importlib.metadata import version as _pkg_version
+
 from stuntdouble.builder import MockBuilder
 from stuntdouble.config import (
     extract_scenario_metadata_from_config,
@@ -30,7 +32,7 @@ from stuntdouble.wrapper import (
     mockable_tool_wrapper,
 )
 
-__version__ = "0.1.0"
+__version__ = _pkg_version("stuntdouble")
 
 __all__ = [
     "CallRecord",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,17 @@
+# ABOUTME: Tests that the package version is consistent between pyproject.toml and __init__.py.
+# ABOUTME: Ensures __version__ is dynamically derived from package metadata.
+
+import importlib.metadata
+
+import stuntdouble
+
+
+def test_version_matches_package_metadata():
+    """__version__ should match the version declared in pyproject.toml."""
+    expected = importlib.metadata.version("stuntdouble")
+    assert stuntdouble.__version__ == expected
+
+
+def test_version_is_not_hardcoded_placeholder():
+    """__version__ should not be the old hardcoded placeholder."""
+    assert stuntdouble.__version__ != "0.1.0"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `__version__ = "0.1.0"` in `__init__.py` with a dynamic read from `importlib.metadata`, so the version always matches `pyproject.toml` (`2.1.2`)
- Adds tests to verify version consistency and prevent future drift

Closes #32

## Test plan
- [x] `test_version_matches_package_metadata` — asserts `__version__` equals `importlib.metadata.version("stuntdouble")`
- [x] `test_version_is_not_hardcoded_placeholder` — asserts `__version__` is not the old `"0.1.0"` value
- [x] Full test suite (478 tests) passes
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)