### PR TITLE
fix: correct version, Python requirement, and API surface docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ uv run mypy src/                 # Type check
 ## Conventions
 
 - Line length: 120 (ruff)
-- Python: 3.11+
+- Python: 3.12+
 - Build: hatchling
 - Package manager: uv
-- All public API exported from `stuntdouble.__init__`
-- No subpackage public APIs (import from `stuntdouble`, not `stuntdouble.X`)
+- Core mocking API exported from `stuntdouble.__init__`
+- MCP mirroring API exported from `stuntdouble.mirroring`

--- a/README.md
+++ b/README.md
@@ -506,10 +506,8 @@ wrapper = create_mockable_tool_wrapper(
 
 ## MCP Tool Mirroring
 
-> **Note:** MCP server auto-discovery requires the `stuntdouble.mcp` client module,
-> which is not yet published. The mirroring infrastructure (registry, strategies,
-> LangChain adapter) is available, but live MCP server connections will raise
-> `ImportError` until the MCP client package is shipped.
+> **Note:** Live MCP server connections (HTTP/SSE) require the optional `aiohttp` dependency.
+> Install with `pip install stuntdouble[mcp]`. Stdio-based servers work out of the box.
 
 Auto-discover and mock tools from MCP servers:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+from importlib.metadata import version as _pkg_version
+
 project = "StuntDouble"
 copyright = "2025-2026, StuntDouble Contributors"
 author = "Benjamin Benchaya"
-release = "0.1.0"
+release = _pkg_version("stuntdouble")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
- docs/conf.py: derive release version from package metadata instead of hardcoded "0.1.0"
- CLAUDE.md: fix Python version from 3.11+ to 3.12+ to match pyproject.toml
- CLAUDE.md: document stuntdouble.mirroring as a second public API surface
- README.md: replace stale "not yet published" MCP client note with accurate guidance on the stuntdouble[mcp] optional extra

Made-with: Cursor

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

Fixes #(issue number)

Thank you!
