### PR TITLE
fix: await async mock factories in tool wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ result = await graph.ainvoke({"messages": [HumanMessage("List my bills")]})
 # --> Uses real list_bills tool
 ```
 
+Mock factories can be defined with either `def` or `async def`. If a factory
+needs to do asynchronous setup before returning the mock callable, the wrapper
+will await it automatically:
+
+```python
+async def async_customer_factory(scenario_metadata, config=None):
+    fixture = await load_fixture(scenario_metadata["fixture_id"])
+    return lambda customer_id: {"id": customer_id, "fixture": fixture}
+
+registry.register("get_customer", mock_fn=async_customer_factory)
+```
+
 ---
 
 ## Data-Driven Mocks
@@ -576,10 +588,10 @@ from stuntdouble import (
 |----------|-------------|
 | `MockToolsRegistry()` | Create a registry for mock functions |
 | `registry.mock(tool_name)` | Start fluent builder chain, returns `MockBuilder` |
-| `registry.register(tool_name, mock_fn, when=None, tool=None)` | Register a mock factory (low-level). Pass `tool=` for signature validation |
+| `registry.register(tool_name, mock_fn, when=None, tool=None)` | Register a sync or async mock factory (low-level). Pass `tool=` for signature validation |
 | `registry.register_data_driven(tool_name, fallback=None, echo_input=False)` | Register a data-driven mock |
-| `registry.resolve(tool_name, scenario_metadata, config=None)` | Resolve the mock callable at runtime |
-| `create_mockable_tool_wrapper(registry, recorder=, tools=, validate_signatures=)` | Create awrap_tool_call wrapper |
+| `registry.resolve(tool_name, scenario_metadata, config=None)` | Resolve the mock callable at runtime. Async factories return an awaitable that the wrapper awaits |
+| `create_mockable_tool_wrapper(registry, recorder=, tools=, validate_signatures=)` | Create awrap_tool_call wrapper with support for sync and async mock factories |
 | `inject_scenario_metadata(config, metadata)` | Create config with scenario_metadata |
 | `CallRecorder()` | Records tool calls for test assertions |
 

--- a/src/stuntdouble/mock_registry.py
+++ b/src/stuntdouble/mock_registry.py
@@ -13,6 +13,10 @@ Mock Factory Signatures:
     - Old: mock_fn(scenario_metadata) -> mock_callable
     - New: mock_fn(scenario_metadata, config) -> mock_callable
 
+    Factories may be defined with either `def` or `async def`. Async factories
+    return an awaitable from resolve(), and the LangGraph wrapper awaits that
+    awaitable before invoking the resolved mock callable.
+
     The new signature allows access to RunnableConfig for extracting runtime context
     like user identity from HTTP headers, useful for no-argument tools.
 
@@ -98,8 +102,9 @@ class MockToolsRegistry:
         Args:
             tool_name: Name of the tool to mock (must match tool.name in LangGraph)
             mock_fn: Function that takes scenario_metadata dict and returns a
-                    callable mock function. The mock function should accept the
-                    same parameters as the real tool.
+                    callable mock function. Factories may be sync or async. The
+                    resolved mock function should accept the same parameters as
+                    the real tool.
             when: Optional predicate function that takes scenario_metadata and
                   returns True if mocking should apply for this tool in this
                   scenario. If None, mocking always applies when resolved.
@@ -192,8 +197,9 @@ class MockToolsRegistry:
         Resolution logic:
         1. If tool_name not registered -> returns None
         2. If `when` predicate exists and returns False -> returns None
-        3. Otherwise -> calls mock_fn(scenario_metadata, config) or mock_fn(scenario_metadata)
-           depending on factory signature, and returns the callable
+        3. Otherwise -> calls mock_fn(scenario_metadata, config) or
+           mock_fn(scenario_metadata) depending on factory signature, and
+           returns the resolved callable or awaitable
 
         Args:
             tool_name: Name of the tool to resolve mock for
@@ -202,7 +208,8 @@ class MockToolsRegistry:
                    Passed to mock factories that accept a second parameter.
 
         Returns:
-            A callable mock function if resolved, None if:
+            A callable mock function, or an awaitable that resolves to one,
+            if resolved. Returns None if:
             - Tool not registered
             - `when` predicate returned False
 

--- a/src/stuntdouble/types.py
+++ b/src/stuntdouble/types.py
@@ -6,7 +6,7 @@ Types are self-contained with no dependencies on existing StuntDouble models.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, TypedDict, runtime_checkable
 
 
@@ -41,10 +41,13 @@ class ScenarioMetadata(TypedDict, total=False):
 # Supports both old and new signatures:
 # - Old: mock_fn(scenario_metadata) -> mock_callable
 # - New: mock_fn(scenario_metadata, config) -> mock_callable
-# The sig.bind() approach in resolve() handles both at runtime.
+# Factories may be sync or async. Async factories are awaited by the
+# LangGraph wrapper before the resolved mock callable is invoked.
 MockFn = (
     Callable[[dict[str, Any]], Callable[..., Any] | None]
     | Callable[[dict[str, Any], dict[str, Any] | None], Callable[..., Any] | None]
+    | Callable[[dict[str, Any]], Awaitable[Callable[..., Any] | None]]
+    | Callable[[dict[str, Any], dict[str, Any] | None], Awaitable[Callable[..., Any] | None]]
 )
 
 # Type alias for "when" predicate function

--- a/src/stuntdouble/wrapper.py
+++ b/src/stuntdouble/wrapper.py
@@ -3,10 +3,13 @@ Mockable tool wrapper for conditional mocking based on scenario_metadata.
 
 Provides the create_mockable_tool_wrapper factory function that creates
 a wrapper suitable for use with native ToolNode's awrap_tool_call parameter.
+The wrapper supports both sync and async mock factories, as well as sync and
+async resolved mock callables.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import time
@@ -52,11 +55,13 @@ def create_mockable_tool_wrapper(
     3. If scenario_metadata present:
        a. Try to resolve mock from registry
        b. If tools provided and validate_signatures=True → validate mock signature
-       c. If mock exists and valid → execute mock and return ToolMessage
+       c. If mock exists and valid → await async factory results if needed,
+          execute mock, and return ToolMessage
        d. If no mock → raise MissingMockError or fallback to real tool
 
     Args:
-        registry: MockToolsRegistry with registered mock factories
+        registry: MockToolsRegistry with registered mock factories. Factories
+            may be sync or async, and may return sync or async mock callables.
         require_mock_when_scenario: If True (default), raise MissingMockError
             when scenario_metadata is present but no mock exists for a tool.
             If False, fall back to executing the real tool.
@@ -227,9 +232,12 @@ def create_mockable_tool_wrapper(
 
             start_time = time.time()
             try:
+                if inspect.isawaitable(mock_callable):
+                    mock_callable = await cast(Awaitable[Callable[..., Any]], mock_callable)
+
                 mock_result = mock_callable(**tool_args)
 
-                if hasattr(mock_result, "__await__"):
+                if inspect.isawaitable(mock_result):
                     mock_result = await mock_result
 
                 content = _format_mock_result(mock_result)

--- a/tests-e2e/test_integration.py
+++ b/tests-e2e/test_integration.py
@@ -453,6 +453,77 @@ class TestCustomMockFactoryE2E:
         await _invoke(graph, config)
         recorder.assert_called("list_items")
 
+    async def test_async_factory_resolves_through_toolnode(self):
+        registry = MockToolsRegistry()
+        recorder = CallRecorder()
+
+        async def async_customer_factory(scenario_metadata: dict, config: dict = None):
+            return lambda customer_id: {
+                "id": customer_id,
+                "tier": scenario_metadata["customer_tier"],
+            }
+
+        registry.register("get_customer", mock_fn=async_customer_factory)
+
+        graph, config = _run_graph(
+            registry,
+            recorder,
+            [
+                make_tool_call("get_customer", {"customer_id": "C1"}),
+                make_final_response("Done."),
+            ],
+            {"scenario_id": "async-factory-test", "customer_tier": "enterprise"},
+        )
+
+        result = await _invoke(graph, config)
+
+        recorder.assert_called_with("get_customer", customer_id="C1")
+        assert recorder.calls[0].was_mocked is True
+        assert recorder.calls[0].result == {"id": "C1", "tier": "enterprise"}
+        assert result["messages"][-1].content == "Done."
+
+    async def test_sync_and_async_factories_can_share_registry(self):
+        registry = MockToolsRegistry()
+        recorder = CallRecorder()
+
+        registry.register(
+            "get_customer",
+            mock_fn=lambda scenario_metadata, config=None: lambda customer_id: {
+                "id": customer_id,
+                "tier": scenario_metadata["customer_tier"],
+            },
+        )
+
+        async def async_items_factory(scenario_metadata: dict, config: dict = None):
+            return lambda status="": {
+                "items": [{"id": "I1", "status": status}],
+                "source": scenario_metadata["source"],
+            }
+
+        registry.register("list_items", mock_fn=async_items_factory)
+
+        graph, config = _run_graph(
+            registry,
+            recorder,
+            [
+                make_tool_call("get_customer", {"customer_id": "C1"}, call_id="call_customer"),
+                make_tool_call("list_items", {"status": "active"}, call_id="call_items"),
+                make_final_response("Done."),
+            ],
+            {"scenario_id": "mixed-factory-test", "customer_tier": "gold", "source": "async"},
+        )
+
+        result = await _invoke(graph, config)
+
+        assert [call.tool_name for call in recorder.calls] == ["get_customer", "list_items"]
+        assert all(call.was_mocked for call in recorder.calls)
+        assert recorder.calls[0].result == {"id": "C1", "tier": "gold"}
+        assert recorder.calls[1].result == {
+            "items": [{"id": "I1", "status": "active"}],
+            "source": "async",
+        }
+        assert result["messages"][-1].content == "Done."
+
 
 # -- 8. Mock vs Real Toggle ---------------------------------------------------
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -362,6 +362,56 @@ class TestCreateMockableToolWrapper:
 
         assert "async_result" in result.content
 
+    def test_async_factory_is_awaited_before_mock_execution(self):
+        """Test that async mock factories are awaited before calling the resolved mock."""
+        from stuntdouble import MockToolsRegistry
+        from stuntdouble.wrapper import create_mockable_tool_wrapper
+
+        registry = MockToolsRegistry()
+
+        async def async_factory(scenario_metadata, config=None):
+            await asyncio.sleep(0)
+            return lambda city: {"city": city, "mode": scenario_metadata["mode"]}
+
+        registry.register("test_tool", mock_fn=async_factory)
+
+        wrapper = create_mockable_tool_wrapper(registry)
+        request = self._create_request(
+            tool_args={"city": "NYC"},
+            scenario_metadata={"mode": "mock"},
+        )
+
+        async def mock_execute(req):
+            raise AssertionError("Execute should not be called")
+
+        result = run_async(wrapper(request, mock_execute))
+
+        assert result.status == "success"
+        assert '"city": "NYC"' in result.content
+        assert '"mode": "mock"' in result.content
+
+    def test_async_factory_error_reraises_in_strict_mode(self):
+        """Test that strict mode re-raises exceptions from async mock factories."""
+        from stuntdouble import MockToolsRegistry
+        from stuntdouble.wrapper import create_mockable_tool_wrapper
+
+        registry = MockToolsRegistry()
+
+        async def failing_factory(scenario_metadata, config=None):
+            await asyncio.sleep(0)
+            raise RuntimeError("factory blew up")
+
+        registry.register("test_tool", mock_fn=failing_factory)
+
+        wrapper = create_mockable_tool_wrapper(registry, strict_mock_errors=True)
+        request = self._create_request(scenario_metadata={"mode": "mock"})
+
+        async def mock_execute(req):
+            raise AssertionError("Execute should not be called")
+
+        with pytest.raises(RuntimeError, match="factory blew up"):
+            run_async(wrapper(request, mock_execute))
+
 
 class TestWrapperIntegration:
     """Integration tests for wrapper with registry."""


### PR DESCRIPTION
Support async mock factories in the ToolNode wrapper so mocks that need async setup resolve correctly without leaking coroutine objects. Add regression coverage for ToolNode, mixed factory types, and async factory failures, and document the supported factory semantics.


### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

Fixes #(issue number)

Thank you!
