### PR TITLE
chore: add ABOUTME comments to all source files

### DIFF
--- a/src/stuntdouble/__init__.py
+++ b/src/stuntdouble/__init__.py
@@ -1,4 +1,6 @@
-"""StuntDouble — Tool mocking framework for AI agent testing."""
+# ABOUTME: Exposes the public StuntDouble import surface from one top-level package module.
+# ABOUTME: Re-exports the main wrappers, registries, builders, validators, recorders, and helper functions.
+"""StuntDouble - Tool mocking framework for AI agent testing."""
 
 from importlib.metadata import version as _pkg_version
 

--- a/src/stuntdouble/builder.py
+++ b/src/stuntdouble/builder.py
@@ -1,3 +1,5 @@
+# ABOUTME: Defines the fluent MockBuilder API for registering mocks with chained calls.
+# ABOUTME: Turns concise when/returns-style declarations into registry-backed mock factories.
 """
 Fluent mock builder API for concise mock registration.
 

--- a/src/stuntdouble/config.py
+++ b/src/stuntdouble/config.py
@@ -1,3 +1,5 @@
+# ABOUTME: Handles reading and writing scenario metadata in LangGraph RunnableConfig objects.
+# ABOUTME: Provides helpers that bridge StuntDouble's config format with runtime tool requests.
 """
 Scenario metadata configuration utilities.
 

--- a/src/stuntdouble/exceptions.py
+++ b/src/stuntdouble/exceptions.py
@@ -1,3 +1,5 @@
+# ABOUTME: Collects the custom exception types raised by StuntDouble during mocking and assertions.
+# ABOUTME: Gives callers stable error classes for missing mocks, signature mismatches, and recorder failures.
 """
 StuntDouble exceptions.
 """

--- a/src/stuntdouble/matching.py
+++ b/src/stuntdouble/matching.py
@@ -1,3 +1,5 @@
+# ABOUTME: Implements input matching logic for mock cases, including operator-based comparisons.
+# ABOUTME: Lets scenario-driven mocks select responses based on tool arguments such as ranges and patterns.
 """
 Input matchers for enhanced mock pattern matching.
 

--- a/src/stuntdouble/mirroring/__init__.py
+++ b/src/stuntdouble/mirroring/__init__.py
@@ -1,3 +1,5 @@
+# ABOUTME: Exposes the public API for the MCP mirroring subsystem from one package entry point.
+# ABOUTME: Re-exports the main mirroring classes and helpers used to discover and generate tool mocks.
 """
 MCP Tool Mirroring - Auto-discover and mock MCP server tools.
 

--- a/src/stuntdouble/mirroring/cache.py
+++ b/src/stuntdouble/mirroring/cache.py
@@ -1,3 +1,5 @@
+# ABOUTME: Provides caching utilities for generated mock responses in the mirroring workflow.
+# ABOUTME: Keeps repeated dynamic generations stable and avoids regenerating identical responses.
 """Response caching for dynamic mock generation.
 
 Provides thread-safe in-memory caching of dynamically generated mock responses

--- a/src/stuntdouble/mirroring/discovery.py
+++ b/src/stuntdouble/mirroring/discovery.py
@@ -1,3 +1,5 @@
+# ABOUTME: Discovers tools exposed by MCP servers and analyzes their schemas for mirroring.
+# ABOUTME: Forms the first step of the mirroring pipeline by turning remote tool metadata into local structures.
 """
 Tool discovery from MCP servers.
 

--- a/src/stuntdouble/mirroring/generation/__init__.py
+++ b/src/stuntdouble/mirroring/generation/__init__.py
@@ -1,3 +1,5 @@
+# ABOUTME: Exposes the mock generation package API for presets, strategies, and generator building blocks.
+# ABOUTME: Gives the mirroring subsystem a compact import surface for response generation features.
 """
 Mock generation system with strategy pattern.
 

--- a/src/stuntdouble/mirroring/generation/base.py
+++ b/src/stuntdouble/mirroring/generation/base.py
@@ -1,3 +1,5 @@
+# ABOUTME: Coordinates mock generation by routing requests through the selected mirroring strategy.
+# ABOUTME: Provides the shared generator foundation used by static and dynamic response builders.
 """
 Strategy-based mock generator.
 

--- a/src/stuntdouble/mirroring/generation/entity.py
+++ b/src/stuntdouble/mirroring/generation/entity.py
@@ -1,3 +1,5 @@
+# ABOUTME: Infers domain entities and produces static field values for realistic generated responses.
+# ABOUTME: Encodes reusable heuristics for common business objects like customers, products, and orders.
 """
 Entity type inference and static field generation.
 

--- a/src/stuntdouble/mirroring/generation/presets.py
+++ b/src/stuntdouble/mirroring/generation/presets.py
@@ -1,3 +1,5 @@
+# ABOUTME: Defines named quality presets for configuring mirroring and mock generation behavior.
+# ABOUTME: Lets callers choose tradeoffs between speed, determinism, and output richness.
 """
 Quality presets for mock generation.
 

--- a/src/stuntdouble/mirroring/generation/responses.py
+++ b/src/stuntdouble/mirroring/generation/responses.py
@@ -1,3 +1,5 @@
+# ABOUTME: Builds response payload shapes for CRUD-style and generic mirrored tool operations.
+# ABOUTME: Encapsulates operation-specific output conventions so generators can stay consistent.
 """
 Response builders for different operation types.
 

--- a/src/stuntdouble/mirroring/integrations/__init__.py
+++ b/src/stuntdouble/mirroring/integrations/__init__.py
@@ -1,3 +1,5 @@
+# ABOUTME: Exposes adapter modules that connect mirroring features to external libraries and services.
+# ABOUTME: Provides a small integration-layer import surface for LangChain and LLM-backed generation.
 """
 Integration adapters for external systems.
 

--- a/src/stuntdouble/mirroring/integrations/langchain.py
+++ b/src/stuntdouble/mirroring/integrations/langchain.py
@@ -1,3 +1,5 @@
+# ABOUTME: Adapts mirrored tool definitions into LangChain-compatible tool objects.
+# ABOUTME: Lets generated MCP mocks plug into LangChain and LangGraph tool execution workflows.
 """
 LangChain integration for mirrored tools.
 

--- a/src/stuntdouble/mirroring/integrations/llm.py
+++ b/src/stuntdouble/mirroring/integrations/llm.py
@@ -1,3 +1,5 @@
+# ABOUTME: Connects the mirroring system to LangChain-compatible LLM clients for dynamic generation.
+# ABOUTME: Produces richer mock outputs when schema-only generation is not enough.
 """
 LLM-powered mock generation.
 

--- a/src/stuntdouble/mirroring/mcp_client.py
+++ b/src/stuntdouble/mirroring/mcp_client.py
@@ -1,3 +1,5 @@
+# ABOUTME: Implements the MCP client used to connect to servers, list tools, and invoke them when needed.
+# ABOUTME: Handles the protocol-level interactions required by the mirroring and discovery features.
 """
 MCP Client for connecting to MCP servers and listing/calling tools.
 

--- a/src/stuntdouble/mirroring/mcp_utils.py
+++ b/src/stuntdouble/mirroring/mcp_utils.py
@@ -1,3 +1,5 @@
+# ABOUTME: Holds shared helper functions used by the MCP client and related mirroring flows.
+# ABOUTME: Keeps lower-level parsing and utility logic out of the higher-level mirroring modules.
 """
 Utility functions for MCP client operations.
 

--- a/src/stuntdouble/mirroring/mirror.py
+++ b/src/stuntdouble/mirroring/mirror.py
@@ -1,3 +1,5 @@
+# ABOUTME: Defines the high-level ToolMirror API that orchestrates discovery, generation, and export.
+# ABOUTME: Serves as the main user-facing entry point for turning MCP tools into usable StuntDouble mocks.
 """
 Simplified ToolMirror - Dead simple by default, powerful when needed.
 """

--- a/src/stuntdouble/mirroring/mirror_registry.py
+++ b/src/stuntdouble/mirroring/mirror_registry.py
@@ -1,3 +1,5 @@
+# ABOUTME: Tracks mirrored tool metadata and manages registration of generated mocks into registries.
+# ABOUTME: Bridges mirrored tool definitions with the runtime registries used by LangGraph integrations.
 """
 Registry for managing mirrored tools.
 

--- a/src/stuntdouble/mirroring/models.py
+++ b/src/stuntdouble/mirroring/models.py
@@ -1,3 +1,5 @@
+# ABOUTME: Defines the core data models used throughout MCP discovery and mock mirroring.
+# ABOUTME: Gives the mirroring pipeline typed structures for tools, parameters, strategies, and metadata.
 """
 Data models for MCP Tool Mirror functionality.
 

--- a/src/stuntdouble/mirroring/strategies.py
+++ b/src/stuntdouble/mirroring/strategies.py
@@ -1,3 +1,5 @@
+# ABOUTME: Declares the strategy interfaces and concrete approaches for generating mock responses.
+# ABOUTME: Lets the mirroring system swap between fast static generation and higher-quality dynamic generation.
 """
 Mock generation strategies.
 

--- a/src/stuntdouble/mock_registry.py
+++ b/src/stuntdouble/mock_registry.py
@@ -1,3 +1,5 @@
+# ABOUTME: Stores mock registrations and resolves the right mock callable for each tool invocation.
+# ABOUTME: Supports plain factories, conditional mocking, and data-driven mock registration on one registry.
 """
 MockToolsRegistry - Mocked tool registration for per-invocation mocking.
 

--- a/src/stuntdouble/recorder.py
+++ b/src/stuntdouble/recorder.py
@@ -1,3 +1,5 @@
+# ABOUTME: Records tool calls and exposes helpers for inspecting and asserting on invocation history.
+# ABOUTME: Powers pytest-style checks for tool order, arguments, results, and mocked-versus-real execution.
 """
 Call recording and verification utilities for mock testing.
 

--- a/src/stuntdouble/resolving.py
+++ b/src/stuntdouble/resolving.py
@@ -1,3 +1,5 @@
+# ABOUTME: Resolves dynamic placeholders inside mock outputs before results are returned to callers.
+# ABOUTME: Supports timestamps, generated IDs, input echoes, and other runtime-derived values.
 """
 Value resolvers for dynamic mock outputs.
 

--- a/src/stuntdouble/scenario_mocking.py
+++ b/src/stuntdouble/scenario_mocking.py
@@ -1,3 +1,5 @@
+# ABOUTME: Implements data-driven mock factories that read cases directly from scenario metadata.
+# ABOUTME: Provides the generic register_data_driven path used for matcher/resolver-based mocking.
 """
 Data-driven mock factories for scenario_metadata-based mocking.
 

--- a/src/stuntdouble/types.py
+++ b/src/stuntdouble/types.py
@@ -1,3 +1,5 @@
+# ABOUTME: Centralizes shared typing aliases and TypedDict shapes used across the package.
+# ABOUTME: Keeps the mocking APIs consistent without creating import cycles between implementation modules.
 """
 Shared type definitions for the StuntDouble mocking system.
 

--- a/src/stuntdouble/validation.py
+++ b/src/stuntdouble/validation.py
@@ -1,3 +1,5 @@
+# ABOUTME: Validates mock signatures and scenario mock inputs against the real tool definitions.
+# ABOUTME: Helps catch bad mock configuration before or during graph execution.
 """
 Tool parameter validation utilities.
 

--- a/src/stuntdouble/wrapper.py
+++ b/src/stuntdouble/wrapper.py
@@ -1,3 +1,5 @@
+# ABOUTME: Wraps LangGraph tool execution so calls can be routed to mocks at runtime.
+# ABOUTME: Connects scenario metadata, registry resolution, validation, and call recording in one entry point.
 """
 Mockable tool wrapper for conditional mocking based on scenario_metadata.
 


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit and integration tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
This change adds a consistent two-line ABOUTME: comment to every Python source file under src/stuntdouble/.

The goal is to make the codebase easier to navigate for new contributors by giving each module a short, grep-friendly summary of what it does. With these comments in place, contributors can quickly scan the project structure using ABOUTME: markers to understand the purpose of each file.

This is a comment-only maintenance change and does not alter runtime behavior.

Fixes #34

Thank you!