### PR TITLE
docs: replace dead proton email with GitHub private advisory link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **stuntdouble@proton.me**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the community leaders responsible for enforcement by [opening a private report](https://github.com/intuit/StuntDouble/security/advisories/new). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in StuntDouble, please report it respon
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email **stuntdouble@proton.me** with:
+Instead, please [open a private security advisory](https://github.com/intuit/StuntDouble/security/advisories/new) with:
 
 - A description of the vulnerability
 - Steps to reproduce the issue


### PR DESCRIPTION
The stuntdouble@proton.me address in CODE_OF_CONDUCT.md and SECURITY.md is not a live mailbox. Point both reporting channels at the repo's private security advisory form now that private reporting is enabled.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

Fixes #(issue number)

Thank you!
